### PR TITLE
Configure Jest testing

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: "jest-expo",
+};
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "test": "jest"
   },
   "dependencies": {
     "@eva-design/eva": "^2.2.0",
@@ -37,7 +38,10 @@
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@types/react": "~19.0.10",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "@types/jest": "^29.5.12",
+    "jest": "^29.7.0",
+    "react-test-renderer": "19.0.0"
   },
   "private": true
 }

--- a/src/components/EquityChart/index.test.tsx
+++ b/src/components/EquityChart/index.test.tsx
@@ -1,3 +1,4 @@
+import { describe, it, expect } from "@jest/globals";
 import React from 'react';
 import renderer from 'react-test-renderer';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
-  "compilerOptions": {},
-  "extends": "expo/tsconfig.base"
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": { "types": ["jest"] },
+  "include": ["src", "**/*.test.ts", "**/*.test.tsx"]
 }


### PR DESCRIPTION
## Summary
- add test script and Jest-related dev dependencies
- expose Jest globals in tsconfig
- import Jest globals in EquityChart tests and add jest-expo preset

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e29af978c832fb6c449f96d32e5ec