### PR TITLE
test: add useChartScales hook tests

### DIFF
--- a/src/hooks/__snapshots__/useChartScales.test.ts.snap
+++ b/src/hooks/__snapshots__/useChartScales.test.ts.snap
@@ -1,0 +1,164 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useChartScales hook calculates scales and windowed history for given params 1`] = `
+{
+  "height": 220,
+  "margin": {
+    "bottom": 28,
+    "left": 42,
+    "right": 16,
+    "top": 24,
+  },
+  "maxPan": 3,
+  "nVisible": 3,
+  "startIndex": 1,
+  "width": 360,
+  "windowedHistory": [
+    105,
+    null,
+    95,
+  ],
+  "xScale": {
+    "domain": [
+      1,
+      3,
+    ],
+    "range": [
+      42,
+      344,
+    ],
+  },
+  "yScale": {
+    "domain": [
+      94.5,
+      105.5,
+    ],
+    "range": [
+      192,
+      24,
+    ],
+  },
+  "yticks": [
+    95,
+    96,
+    97,
+    98,
+    99,
+    100,
+    101,
+    102,
+    103,
+    104,
+    105,
+  ],
+}
+`;
+
+exports[`useChartScales hook expands y domain and generates ticks for flat history 1`] = `
+{
+  "height": 220,
+  "margin": {
+    "bottom": 28,
+    "left": 42,
+    "right": 16,
+    "top": 24,
+  },
+  "maxPan": 0,
+  "nVisible": 5,
+  "startIndex": 0,
+  "width": 360,
+  "windowedHistory": [
+    100,
+    100,
+    100,
+    100,
+    100,
+  ],
+  "xScale": {
+    "domain": [
+      0,
+      4,
+    ],
+    "range": [
+      42,
+      344,
+    ],
+  },
+  "yScale": {
+    "domain": [
+      50,
+      150,
+    ],
+    "range": [
+      192,
+      24,
+    ],
+  },
+  "yticks": [
+    50,
+    60,
+    70,
+    80,
+    90,
+    100,
+    110,
+    120,
+    130,
+    140,
+    150,
+  ],
+}
+`;
+
+exports[`useChartScales hook supports custom zoom and includes initial capital in domain 1`] = `
+{
+  "height": 220,
+  "margin": {
+    "bottom": 28,
+    "left": 42,
+    "right": 16,
+    "top": 24,
+  },
+  "maxPan": 2,
+  "nVisible": 4,
+  "startIndex": 0,
+  "width": 360,
+  "windowedHistory": [
+    1,
+    2,
+    3,
+    4,
+  ],
+  "xScale": {
+    "domain": [
+      0,
+      3,
+    ],
+    "range": [
+      42,
+      344,
+    ],
+  },
+  "yScale": {
+    "domain": [
+      -0.4,
+      4.4,
+    ],
+    "range": [
+      192,
+      24,
+    ],
+  },
+  "yticks": [
+    0,
+    0.5,
+    1,
+    1.5,
+    2,
+    2.5,
+    3,
+    3.5,
+    4,
+  ],
+}
+`;

--- a/src/hooks/useChartScales.test.ts
+++ b/src/hooks/useChartScales.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeAll } from '@jest/globals';
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+
+import useChartScales from './useChartScales';
+
+beforeAll(() => {
+  // Disable development logs in tests
+  // @ts-ignore
+  global.__DEV__ = false;
+});
+
+function renderHook(props: Parameters<typeof useChartScales>[0]) {
+  let hookResult: ReturnType<typeof useChartScales>;
+  function TestComponent() {
+    hookResult = useChartScales(props);
+    return null;
+  }
+  act(() => {
+    renderer.create(React.createElement(TestComponent));
+  });
+  return hookResult!;
+}
+
+describe('useChartScales hook', () => {
+  it('calculates scales and windowed history for given params', () => {
+    const result = renderHook({
+      history: [100, 105, null, 95, 110, 90],
+      nVisible: 3,
+      panOffset: 1,
+      nTicks: 5,
+      initialCapital: 100,
+      yZoom: 1,
+    });
+
+    expect(result.windowedHistory).toEqual([105, null, 95]);
+    expect(result.maxPan).toBe(3);
+    expect(result.xScale.domain()).toEqual([1, 3]);
+    expect(result.yScale.domain()).toEqual([94.5, 105.5]);
+
+    const snapshot = {
+      xScale: {
+        domain: result.xScale.domain(),
+        range: result.xScale.range(),
+      },
+      yScale: {
+        domain: result.yScale.domain(),
+        range: result.yScale.range(),
+      },
+      yticks: result.yticks,
+      width: result.width,
+      height: result.height,
+      margin: result.margin,
+      windowedHistory: result.windowedHistory,
+      maxPan: result.maxPan,
+      startIndex: result.startIndex,
+      nVisible: result.nVisible,
+    };
+    expect(snapshot).toMatchSnapshot();
+  });
+
+  it('supports custom zoom and includes initial capital in domain', () => {
+    const result = renderHook({
+      history: [1, 2, 3, 4, 5, 6],
+      nVisible: 4,
+      panOffset: 0,
+      nTicks: 5,
+      initialCapital: 0,
+      yZoom: 2,
+    });
+
+    expect(result.windowedHistory).toEqual([1, 2, 3, 4]);
+    expect(result.maxPan).toBe(2);
+    expect(result.xScale.domain()).toEqual([0, 3]);
+    expect(result.yScale.domain()).toEqual([-0.4, 4.4]);
+
+    const snapshot = {
+      xScale: {
+        domain: result.xScale.domain(),
+        range: result.xScale.range(),
+      },
+      yScale: {
+        domain: result.yScale.domain(),
+        range: result.yScale.range(),
+      },
+      yticks: result.yticks,
+      width: result.width,
+      height: result.height,
+      margin: result.margin,
+      windowedHistory: result.windowedHistory,
+      maxPan: result.maxPan,
+      startIndex: result.startIndex,
+      nVisible: result.nVisible,
+    };
+    expect(snapshot).toMatchSnapshot();
+  });
+
+  it('expands y domain and generates ticks for flat history', () => {
+    const history = Array(5).fill(100);
+    const result = renderHook({
+      history,
+      nVisible: 5,
+      panOffset: 0,
+      nTicks: 10,
+      initialCapital: 100,
+      yZoom: 1,
+    });
+
+    expect(result.maxPan).toBe(0);
+    expect(result.windowedHistory).toEqual(history);
+    expect(result.yScale.domain()).toEqual([50, 150]);
+    expect(result.yticks.length).toBe(11);
+
+    const snapshot = {
+      xScale: {
+        domain: result.xScale.domain(),
+        range: result.xScale.range(),
+      },
+      yScale: {
+        domain: result.yScale.domain(),
+        range: result.yScale.range(),
+      },
+      yticks: result.yticks,
+      width: result.width,
+      height: result.height,
+      margin: result.margin,
+      windowedHistory: result.windowedHistory,
+      maxPan: result.maxPan,
+      startIndex: result.startIndex,
+      nVisible: result.nVisible,
+    };
+    expect(snapshot).toMatchSnapshot();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add comprehensive tests for `useChartScales` covering scale domains, panning, zooming and flat graphs
- snapshot hook output to detect structural changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a213c1b6cc832fa5e522728da57a38